### PR TITLE
docs: add SECURITY.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of positive behavior:
+* Empathy and kindness toward others
+* Respecting differing opinions and experiences
+* Giving and accepting constructive feedback
+* Taking responsibility for mistakes
+* Focusing on what's best for the community
+
+Examples of unacceptable behavior:
+* Sexualized language, imagery, or attention
+* Trolling, insults, derogatory comments
+* Harassment (public or private)
+* Publishing private information without permission
+* Other inappropriate conduct
+
+## Enforcement
+
+Project maintainers are responsible for enforcing these standards and will take fair corrective action for violations.
+
+## Scope
+
+Applies in all community spaces and when representing the community publicly.
+
+## Enforcement
+
+Report violations to project maintainers. All complaints will be reviewed promptly and fairly.
+
+## Attribution
+
+Adapted from [Contributor Covenant v2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to woolang
+
+Thanks for your interest! Here's how to help.
+
+## Quick Start
+
+1. **Fork** the repository
+2. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/woolang.git`
+3. **Create a branch**: `git checkout -b feature/your-feature`
+4. **Make changes**, test thoroughly
+5. **Commit** with clear messages
+6. **Push** and open a **Pull Request**
+
+## Pull Request Guidelines
+
+- One feature/fix per PR
+- Write descriptive commit messages
+- Update docs if needed
+- Add tests for new functionality
+- Link related issues
+
+## Code Style
+
+- Follow existing conventions
+- Use meaningful names
+- Comment complex logic
+- Keep functions focused
+
+## Issues
+
+- Search before creating
+- Include: steps to reproduce, expected vs actual behavior, environment details
+
+## Questions?
+
+Open a discussion or issue — we're happy to help.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+The woolang team takes security seriously. If you discover a security vulnerability:
+
+1. **Do not open a public issue.** Disclose privately.
+2. Use GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) or email the maintainers.
+3. Include: description, reproduction steps, affected versions, potential mitigations.
+
+## Response Timeline
+
+- Acknowledgment within **48 hours**
+- Assessment within **5 business days**
+- Coordinated disclosure once a fix is ready
+
+## Responsible Disclosure
+
+Please allow reasonable time to address vulnerabilities before public disclosure. Credit will be given to researchers who follow responsible disclosure practices.


### PR DESCRIPTION
This PR adds essential community documentation:

- **SECURITY.md** — Security policy and vulnerability reporting
- **CONTRIBUTING.md** — Contribution guidelines
- **CODE_OF_CONDUCT.md** — Contributor Covenant

These help establish community standards and make the project more welcoming to new contributors.